### PR TITLE
More gracefully handle exceeding the API limit.

### DIFF
--- a/POEApi.Infrastructure/Events/ThottledEventArgs.cs
+++ b/POEApi.Infrastructure/Events/ThottledEventArgs.cs
@@ -5,9 +5,15 @@ namespace POEApi.Infrastructure.Events
     public class ThottledEventArgs : EventArgs
     {
         public TimeSpan WaitTime { get; private set; }
-        public ThottledEventArgs(TimeSpan waitTime)
+        /// <summary>
+        /// Whether the throttling event was expected.  If it was not expected, there might be other agents or
+        /// untracked actions using up resources towards the limit.
+        /// </summary>
+        public bool Expected { get; private set; }
+        public ThottledEventArgs(TimeSpan waitTime, bool expected = true)
         {
             WaitTime = waitTime;
+            Expected = expected;
         }
     }
 }

--- a/Procurement/View/RefreshView.xaml.cs
+++ b/Procurement/View/RefreshView.xaml.cs
@@ -77,9 +77,14 @@ namespace Procurement.View
 
         void model_Throttled(object sender, ThottledEventArgs e)
         {
-            if (e.WaitTime.TotalSeconds > 4)
+            if (!e.Expected)
+                update(string.Format("Exceeded GGG Server request limit; throttling activated.  Waiting {0} " +
+                    "seconds.  Ensure you do not have other instances of Procurement running or other apps using " +
+                    "the GGG API with your account.", Convert.ToInt32(e.WaitTime.TotalSeconds)),
+                    new POEEventArgs(POEEventState.BeforeEvent));
+            else if (e.WaitTime.TotalSeconds > 4)
                 update(string.Format("GGG Server request limit hit, throttling activated. Please wait {0} seconds",
-                    e.WaitTime.Seconds), new POEEventArgs(POEEventState.BeforeEvent));
+                    Convert.ToInt32(e.WaitTime.TotalSeconds)), new POEEventArgs(POEEventState.BeforeEvent));
         }
 
         private void update(string message, POEEventArgs e)

--- a/Procurement/ViewModel/LoginWindowViewModel.cs
+++ b/Procurement/ViewModel/LoginWindowViewModel.cs
@@ -337,8 +337,14 @@ namespace Procurement.ViewModel
 
         void Model_Throttled(object sender, ThottledEventArgs e)
         {
-            if (e.WaitTime.TotalSeconds > 4)
-                Update(string.Format("GGG Server request limit hit, throttling activated. Please wait {0} seconds", e.WaitTime.Seconds), new POEEventArgs(POEEventState.BeforeEvent));
+            if (!e.Expected)
+                Update(string.Format("Exceeded GGG Server request limit; throttling activated.  Waiting {0} " +
+                    "seconds.  Ensure you do not have other instances of Procurement running or other apps using " +
+                    "the GGG API with your account.", Convert.ToInt32(e.WaitTime.TotalSeconds)),
+                    new POEEventArgs(POEEventState.BeforeEvent));
+            else if (e.WaitTime.TotalSeconds > 4)
+                Update(string.Format("GGG Server request limit hit, throttling activated. Please wait {0} seconds",
+                    Convert.ToInt32(e.WaitTime.TotalSeconds)), new POEEventArgs(POEEventState.BeforeEvent));
         }
 
         private void Update(string message, POEEventArgs e)


### PR DESCRIPTION
If another tool that uses the GGG API is used alongside Procurement, it
is very easy to exceed the API limit.  This change more gracefully
handles that case, but is very cautious about it.  If an overflow is
detected, completely fill up the window of active tasks, and wait for at
least as long as the window size.